### PR TITLE
database and query changes to use candidateId as key/id

### DIFF
--- a/src/main/java/com/google/sps/CandidateStats.java
+++ b/src/main/java/com/google/sps/CandidateStats.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 public class CandidateStats{
 
-    public String id; 
+    public String name; 
     public String state;
     public String district;
     public String affiliation; 
@@ -18,10 +18,10 @@ public class CandidateStats{
     
     public CandidateStats(){
     }
-    public CandidateStats(String id, String state, String district, String affiliation, 
+    public CandidateStats(String name, String state, String district, String affiliation, 
     String conFromCandidate, String loansFromCandidate, String otherLoans, String individualCon, 
     String conFromPoliticalComm, String conFromPartyComm){
-        this.id = id;; 
+        this.name = name;; 
         this.state = state;
         this.district = district;
         this.affiliation = affiliation; 

--- a/src/main/java/com/google/sps/Database.java
+++ b/src/main/java/com/google/sps/Database.java
@@ -32,7 +32,7 @@ public class Database {
             String[] stats = can.split("\\|"); 
 
             CandidateStats canStats = new CandidateStats(
-                /*candidate id=*/stats[0], 
+                /*candidate id=*/stats[1], 
                 /*state=*/stats[18], 
                 /*district=*/stats[19], 
                 /*affiliation=*/stats[4], 
@@ -47,7 +47,7 @@ public class Database {
 
             initialData.put(filePath.substring(39, 48), canStats);
 
-            String candidateName = stats[1];
+            String candidateId = stats[0];
 
             /* The candidate name must be error-checked as this will become a document ID. 
              * Document IDs cannot contain forward slashes (/). 
@@ -55,11 +55,8 @@ public class Database {
              * Therefore, these must be replaced to fit these constraints.
              */
         
-            if (candidateName.contains("/")){
-                candidateName = candidateName.replace("/", "-");
-            }
 
-            DocumentReference doc = db.collection("fec_data").document(candidateName);
+            DocumentReference doc = db.collection("fec_data").document(candidateId);
             
             ApiFuture<WriteResult> result = doc.set(initialData, SetOptions.merge());
 

--- a/src/main/java/com/google/sps/ServerMain.java
+++ b/src/main/java/com/google/sps/ServerMain.java
@@ -19,7 +19,18 @@ public class ServerMain {
 
     db.initialize();
 
+    /*
     //db.addData("src/main/java/com/google/sps/Bulk Data/2019-2020.txt"); //relative to source
+    //db.addData("src/main/java/com/google/sps/Bulk Data/2017-2018.txt"); //relative to source
+    //db.addData("src/main/java/com/google/sps/Bulk Data/2015-2016.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2013-2014.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2011-2012.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2009-2010.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2007-2008.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2005-2006.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2003-2004.txt"); //relative to source
+    db.addData("src/main/java/com/google/sps/Bulk Data/2001-2002.txt"); //relative to source
+    */
 
     // Create a server that listens on port 8080.
     final Server server = new Server(8080);

--- a/src/main/java/com/google/sps/servlets/CandidateContributionHistoryServlet.java
+++ b/src/main/java/com/google/sps/servlets/CandidateContributionHistoryServlet.java
@@ -17,8 +17,8 @@ public class CandidateContributionHistoryServlet extends SetupServlet {
     @Override
     public void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         try { 
-            String candidateName = request.getParameter("name");
-            ApiFuture<DocumentSnapshot> candidate_snapshot = db.collection("fec_data").document(candidateName).get(); // get candidate
+            String candidateId = request.getParameter("candidateId");
+            ApiFuture<DocumentSnapshot> candidate_snapshot = db.collection("fec_data").document(candidateId).get(); // get candidate
             Map<String,Object> years =  candidate_snapshot.get().getData();
             ArrayList<ArrayList<Object>> results = new ArrayList<ArrayList<Object>>();
             ArrayList<Object> heading = new ArrayList<Object>();

--- a/src/main/java/com/google/sps/servlets/CandidateFundingSourceServlet.java
+++ b/src/main/java/com/google/sps/servlets/CandidateFundingSourceServlet.java
@@ -11,15 +11,15 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentSnapshot;
 
-@WebServlet("/candidatecontributionhistory")
+@WebServlet("/candidatefundingsource")
 public class CandidateFundingSourceServlet extends SetupServlet {
     // not tested yet waiting on Henry's chart to test
     @Override
     public void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         try { 
-            String candidateName = request.getParameter("name");
+            String candidateId = request.getParameter("candidateId");
             String year = request.getParameter("year");
-            ApiFuture<DocumentSnapshot> candidate_snapshot = db.collection("fec_data").document(candidateName).get(); // get candidate
+            ApiFuture<DocumentSnapshot> candidate_snapshot = db.collection("fec_data").document(candidateId).get(); // get candidate
             Object year_data = candidate_snapshot.get().get(year);
             Double conFromCandidate = ((Map<String, Double>) year_data).get("conFromCandidate");
             Double loansFromCandidate = ((Map<String, Double>) year_data).get("loansFromCandidate");

--- a/src/main/java/com/google/sps/servlets/FecApiServlet.java
+++ b/src/main/java/com/google/sps/servlets/FecApiServlet.java
@@ -2,9 +2,10 @@ package com.google.sps.servlets;
 
 import java.io.IOException;
 import java.net.URI;
-
+import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import javax.servlet.annotation.WebServlet;
@@ -25,7 +26,7 @@ public class FecApiServlet extends SetupServlet {
     @Override
     public void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         // build fec query/rquest
-        final String query = request.getParameter("query");
+        final String query = URLEncoder.encode(request.getParameter("query"), StandardCharsets.UTF_8);
         final HttpRequest fec_request = HttpRequest.newBuilder()
             .GET()
             .uri(URI.create("https://api.open.fec.gov/v1/names/candidates/?q=" + query + "&api_key=" + fec_api_key))


### PR DESCRIPTION
These changes are necessary to allow the db to candidateId as the id/key of all documents. 

Queries now expect candidateId rather than candidateName